### PR TITLE
Fix sha1 to sha256 transition on homebrew

### DIFF
--- a/icmake.rb
+++ b/icmake.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Icmake < Formula
   url 'http://downloads.sourceforge.net/project/icmake/icmake/7.22.01/icmake_7.22.01.orig.tar.gz'
   homepage 'http://icmake.sourceforge.net/'
-  sha1 'f10be7bfeb905ed12523738b41a0f040ee403771'
+  sha256 'b522e7937e9d4f0bec738dfce371673e3c4a8bc9f4d209a51631e5ed59ba66c7'
 
   depends_on 'gnu-sed'
 

--- a/yodl.rb
+++ b/yodl.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Yodl < Formula
   url 'http://downloads.sourceforge.net/project/yodl/yodl/3.05.01/yodl_3.05.01.orig.tar.gz'
   homepage 'http://yodl.sourceforge.net/'
-  sha1 '94d8e59a8569a9d6fb4dc7a1b8e7d430f018e570'
+  sha256 '5a3d0e1b2abbba87217cfdc6cd354a00df8d782572495bbddbdfbd4f47fe0d3e'
 
   depends_on "ghostscript"
   depends_on "icmake"


### PR DESCRIPTION
Homebrew now doesn't allow sha1 hashes any longer, need sha256 hashes to work. This patch fixes just that.